### PR TITLE
feat: add grouped security dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+      version-updates:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
This Pull Request adds a Dependabot configuration (`.github/dependabot.yml`) to group security updates.

### Key Changes:
- Group all security updates into a single PR per package ecosystem (`security-updates` group).
- Group regular version updates into a single PR per package ecosystem (`version-updates` group).
- Interval set to `weekly` for all ecosystems to reduce PR frequency.

This prevents repository notifications and PR tabs from being flooded with individual alerts, making dependency maintenance much easier.